### PR TITLE
Add EnvFilter to tracing initialization (enables RUST_LOG)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target
+
+# JetBrains files
+.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "flv-util"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flv-util"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "utilies for Fluvio projects"
 repository = "https://github.com/infinyon/flv-future"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -6,6 +6,7 @@ use env_logger::{
     Builder,
 };
 use log::Level;
+use tracing_subscriber::EnvFilter;
 
 
 static MAX_MODULE_WIDTH: AtomicUsize = AtomicUsize::new(0);
@@ -55,5 +56,6 @@ pub fn init_logger() {
 pub fn init_tracer(level: Option<tracing::Level>) {
     tracing_subscriber::fmt()
         .with_max_level(level.unwrap_or(tracing::Level::DEBUG))
+        .with_env_filter(EnvFilter::from_default_env())
         .init();
 }


### PR DESCRIPTION
@sehz I misread the documentation about this being enabled by default. The _feature flag_ for providing `EnvFilter` is enabled by default, but it still needs to be added in code. This PR adds it.