### PR TITLE
Add CommandExt utils. Bump to version 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "flv-util"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flv-util"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "utilies for Fluvio projects"
 repository = "https://github.com/infinyon/flv-future"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,0 +1,93 @@
+use std::io;
+use std::io::Write;
+use std::process::{Command, ExitStatus};
+
+pub trait CommandExt {
+    fn inherit(&mut self);
+
+    // wait and check
+    fn wait_and_check(&mut self);
+
+    // just wait
+    fn wait(&mut self);
+
+    fn print(&mut self) -> &mut Self;
+
+    fn rust_log(&mut self, log_option: Option<&str>) -> &mut Self;
+}
+
+impl CommandExt for Command {
+    /// execute and ensure command has been executed ok
+    fn inherit(&mut self) {
+        use std::process::Stdio;
+
+        self.print();
+
+        let output = self
+            .stdout(Stdio::inherit())
+            .output()
+            .expect("execution failed");
+
+        if !output.status.success() {
+            io::stderr().write_all(&output.stderr).unwrap();
+        }
+
+        output.status.check();
+    }
+
+    /// execute and ensure command has been executed ok
+    fn wait_and_check(&mut self) {
+        self.print();
+
+        let output = self.output().expect("execution failed");
+
+        io::stdout().write_all(&output.stdout).unwrap();
+        io::stderr().write_all(&output.stderr).unwrap();
+
+        output.status.check();
+    }
+
+    /// execute and wait, ignore error
+    fn wait(&mut self) {
+        self.print();
+        let output = self.output().expect("execution failed");
+
+        io::stdout().write_all(&output.stdout).unwrap();
+        io::stderr().write_all(&output.stderr).unwrap();
+    }
+
+    fn print(&mut self) -> &mut Self {
+        use std::env;
+
+        if env::var_os("FLV_CMD").is_some() {
+            println!(">> {}", format!("{:?}", self).replace("\"", ""));
+        }
+
+        self
+    }
+
+    fn rust_log(&mut self, log_option: Option<&str>) -> &mut Self {
+        if let Some(log) = log_option {
+            println!("setting rust log: {}", log);
+            self.env("RUST_LOG", log);
+        }
+
+        self
+    }
+}
+
+trait StatusExt {
+    fn check(&self);
+}
+
+impl StatusExt for ExitStatus {
+    fn check(&self) {
+        if !self.success() {
+            match self.code() {
+                Some(code) => println!("Exited with status code: {}", code),
+                None => println!("Process terminated by signal"),
+            }
+            unreachable!()
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,16 @@
+#[cfg(feature = "fixture")]
+pub mod fixture;
+pub mod cmd;
 mod logger;
+mod concurrent;
+
 pub mod string_helper;
-pub use logger::init_logger;
-pub use logger::init_tracer;
 pub mod actions;
 pub mod socket_helpers;
 pub mod macros;
 
-#[cfg(feature = "fixture")]
-pub mod fixture;
-
-
-mod concurrent;
+pub use logger::init_logger;
+pub use logger::init_tracer;
 
 pub use concurrent::SimpleConcurrentHashMap;
 pub use concurrent::SimpleConcurrentBTreeMap;


### PR DESCRIPTION
I noticed this set of Command utilities is floating around and duplicated. We can consolidate them here and phase them out elsewhere.