### PR TITLE
CommandExt inline() method just forwards `&mut Self`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "flv-util"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flv-util"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "utilies for Fluvio projects"
 repository = "https://github.com/infinyon/flv-future"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,93 +1,24 @@
-use std::io;
-use std::io::Write;
-use std::process::{Command, ExitStatus};
+use std::env;
+use std::process::{Command, Stdio};
 
 pub trait CommandExt {
-    fn inherit(&mut self);
-
-    // wait and check
-    fn wait_and_check(&mut self);
-
-    // just wait
-    fn wait(&mut self);
+    fn inherit(&mut self) -> &mut Self;
 
     fn print(&mut self) -> &mut Self;
-
-    fn rust_log(&mut self, log_option: Option<&str>) -> &mut Self;
 }
 
 impl CommandExt for Command {
-    /// execute and ensure command has been executed ok
-    fn inherit(&mut self) {
-        use std::process::Stdio;
-
-        self.print();
-
-        let output = self
-            .stdout(Stdio::inherit())
-            .output()
-            .expect("execution failed");
-
-        if !output.status.success() {
-            io::stderr().write_all(&output.stderr).unwrap();
-        }
-
-        output.status.check();
+    /// Configure command to inherit parent's stdout and stderr
+    fn inherit(&mut self) -> &mut Self {
+        self.stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
     }
 
-    /// execute and ensure command has been executed ok
-    fn wait_and_check(&mut self) {
-        self.print();
-
-        let output = self.output().expect("execution failed");
-
-        io::stdout().write_all(&output.stdout).unwrap();
-        io::stderr().write_all(&output.stderr).unwrap();
-
-        output.status.check();
-    }
-
-    /// execute and wait, ignore error
-    fn wait(&mut self) {
-        self.print();
-        let output = self.output().expect("execution failed");
-
-        io::stdout().write_all(&output.stdout).unwrap();
-        io::stderr().write_all(&output.stderr).unwrap();
-    }
-
+    /// Print the command as it will be executed
     fn print(&mut self) -> &mut Self {
-        use std::env;
-
         if env::var_os("FLV_CMD").is_some() {
             println!(">> {}", format!("{:?}", self).replace("\"", ""));
         }
-
         self
-    }
-
-    fn rust_log(&mut self, log_option: Option<&str>) -> &mut Self {
-        if let Some(log) = log_option {
-            println!("setting rust log: {}", log);
-            self.env("RUST_LOG", log);
-        }
-
-        self
-    }
-}
-
-trait StatusExt {
-    fn check(&self);
-}
-
-impl StatusExt for ExitStatus {
-    fn check(&self) {
-        if !self.success() {
-            match self.code() {
-                Some(code) => println!("Exited with status code: {}", code),
-                None => println!("Process terminated by signal"),
-            }
-            unreachable!()
-        }
     }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -53,9 +53,8 @@ pub fn init_logger() {
     let _ = builder.try_init();
 }
 
-pub fn init_tracer(level: Option<tracing::Level>) {
+pub fn init_tracer() {
     tracing_subscriber::fmt()
-        .with_max_level(level.unwrap_or(tracing::Level::DEBUG))
         .with_env_filter(EnvFilter::from_default_env())
         .init();
 }


### PR DESCRIPTION
In [this discussion](https://github.com/infinyon/fluvio/pull/236#discussion_r485204880), I mentioned how the current inherit method seems to do too much, by causing the command to execute and possibly panic on failure. This version of `inherit` simply configures the stdout and stderr inheriting and passes the `&mut Command` forward, much like the other Command methods. I've also removed some of the other extension methods because I would like to explore how they might be made more ergonomic as well.

This bumps the version to `0.4.0`.